### PR TITLE
Restore alias directory constant and update tests

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -59,8 +59,10 @@ EXCLUDED_DIRS = ["dist", "node_modules", ".git", "__pycache__"]
 
 # --- Alias Configuration ---
 ALIAS_DIR_NAME = ".onefilellm_aliases"  # Re-use existing constant
-ALIAS_CONFIG_DIR = Path.home() / ALIAS_DIR_NAME
-USER_ALIASES_PATH = ALIAS_CONFIG_DIR / "aliases.json"
+ALIAS_DIR = Path.home() / ALIAS_DIR_NAME
+# Backwards compatibility: some tests and code may reference ALIAS_CONFIG_DIR
+ALIAS_CONFIG_DIR = ALIAS_DIR
+USER_ALIASES_PATH = ALIAS_DIR / "aliases.json"
 
 CORE_ALIASES = {
     "ofl_readme": "https://github.com/jimmc414/onefilellm/blob/main/readme.md",
@@ -73,7 +75,7 @@ CORE_ALIASES = {
 
 def ensure_alias_dir_exists():
     """Ensures the alias directory exists, creating it if necessary."""
-    ALIAS_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    ALIAS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 class AliasManager:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -542,7 +542,7 @@ class TestAliasSystem2(unittest.TestCase):
         self.alias_file = Path(self.temp_alias_dir) / "aliases.json"
         
         # Mock the alias configuration directory
-        self.config_dir_patcher = patch('onefilellm.ALIAS_CONFIG_DIR', Path(self.temp_alias_dir))
+        self.config_dir_patcher = patch('onefilellm.ALIAS_DIR', Path(self.temp_alias_dir))
         self.config_dir_patcher.start()
         
         # Mock the user aliases path
@@ -677,7 +677,7 @@ class TestAdvancedAliasFeatures(unittest.TestCase):
         self.alias_file = Path(self.temp_alias_dir) / "aliases.json"
         
         # Mock the alias configuration directory
-        self.config_dir_patcher = patch('onefilellm.ALIAS_CONFIG_DIR', Path(self.temp_alias_dir))
+        self.config_dir_patcher = patch('onefilellm.ALIAS_DIR', Path(self.temp_alias_dir))
         self.config_dir_patcher.start()
         
         # Mock the user aliases path


### PR DESCRIPTION
## Summary
- Reintroduce `ALIAS_DIR` constant to ensure consistent alias-directory paths and backwards compatibility
- Update tests to patch `ALIAS_DIR` instead of the removed `ALIAS_CONFIG_DIR`

## Testing
- `pytest tests/test_all.py::TestAliasSystem2::test_alias_manager_creation -q`
- `pytest tests/test_all.py::TestAliasSystem2::test_alias_manager_json_storage -q`
- `pytest -q` *(fails: network access for tiktoken/arXiv/web crawl and legacy alias tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c49cb04c348321aebed0bc05465e42