### PR TITLE
chore: upgrade requests to support urllib3 v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "requests==2.28.0",
+    "requests==2.31.0",
     "beautifulsoup4==4.11.1",
     "PyPDF2==2.10.0",
     "tiktoken",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.28.0
+requests==2.31.0
 beautifulsoup4==4.11.1
 PyPDF2==2.10.0
 tiktoken


### PR DESCRIPTION
## Summary
- bump requests to 2.31.0 for urllib3>=2 compatibility
- align pyproject dependency with requests 2.31.0

## Testing
- `pytest -q` (fails: Proxy errors and missing ALIAS_DIR attribute)

------
https://chatgpt.com/codex/tasks/task_e_68c49efb61f08321bd919eed8e64762b