### PR TITLE
Handle stdin and format overrides in CLI

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -3272,14 +3272,17 @@ async def main():
     stream_source_dict = {}
     stream_content_to_process = None
     user_format_override = args.format
-    
-    # Check for stdin input ('-' in inputs)
-    if '-' in args.inputs:
+
+    # Determine stdin usage
+    if '-' in (args.inputs or []):
         is_stream_input_mode = True
         stream_source_dict = {'type': 'stdin'}
         # Remove '-' from inputs list
         args.inputs = [inp for inp in args.inputs if inp != '-']
-    
+    elif not args.inputs and not sys.stdin.isatty():
+        is_stream_input_mode = True
+        stream_source_dict = {'type': 'stdin'}
+
     # Check for clipboard input
     elif args.clipboard:
         is_stream_input_mode = True


### PR DESCRIPTION
## Summary
- Accept piped input when `-` is used or when stdin data is present without explicit arguments
- Apply `--format` overrides to stdin content to ensure correct parsing

## Testing
- `pytest tests/test_all.py::TestCLIFunctionality::test_stdin_input -q`
- `pytest tests/test_all.py::TestCLIFunctionality::test_format_override -q`
- `echo '{"foo": "bar"}' | python onefilellm.py --format json`
- `pytest -q` *(fails: Proxy errors for arxiv.org and docs.anthropic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a841de488321813dee5cc04c2e4e