### PR TITLE
feat: allow downloading all GitHub issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,8 @@ python onefilellm.py https://github.com/microsoft/vscode
 python onefilellm.py https://github.com/openai/whisper/tree/main/whisper
 python onefilellm.py https://github.com/microsoft/vscode/pull/12345
 python onefilellm.py https://github.com/kubernetes/kubernetes/issues
+python onefilellm.py https://github.com/kubernetes/kubernetes/issues?state=open
+python onefilellm.py https://github.com/kubernetes/kubernetes/issues?state=closed
 ```
 
 ### Web Documentation and APIs

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -33,6 +33,7 @@ from onefilellm import (
     process_doi_or_pmid,
     process_github_pull_request,
     process_github_issue,
+    process_github_issues,
     excel_to_markdown,
     process_input,
     process_text_stream,
@@ -1578,9 +1579,16 @@ class TestGitHubIssuesPullRequests(unittest.TestCase):
         """Test GitHub issue error response format"""
         # Test that without a token, we get a properly formatted error response
         result = process_github_issue("https://github.com/user/repo/issues/123")
-        
+
         # Should return properly formatted XML even for errors
         self.assertIn('<source type="github_issue"', result)
+        self.assertIn('error', result.lower())
+
+    def test_github_issues_error_response_format(self):
+        """Test GitHub issues list error response format"""
+        result = process_github_issues("https://github.com/user/repo/issues")
+
+        self.assertIn('<source type="github_issues"', result)
         self.assertIn('error', result.lower())
     
     def test_github_pr_error_response_format(self):


### PR DESCRIPTION
## Summary
- add `process_github_issues` to fetch all, open, or closed issues from a repo
- call new function when URL ends with `/issues`
- document new `?state=` usage and add tests

## Testing
- `python -m pytest -q` *(fails: Proxy error: HTTPSConnectionPool(host='arxiv.org', port=443): Max retries exceeded)*
- `python -m pytest tests/test_all.py::TestIntegration::test_arxiv_integration -q` *(fails: Proxy error: HTTPSConnectionPool(host='arxiv.org', port=443): Max retries exceeded)*
- `python -m pytest tests/test_all.py::TestIntegration::test_web_crawl_integration -q` *(fails: Proxy error: HTTPSConnectionPool(host='docs.anthropic.com', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68c4af6b1ed88321bbdb110c44bdf78e