### PR TITLE
Add timeouts and error handling for HTTP requests

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -218,8 +218,12 @@ def download_file(url: str, target_path: str) -> None:
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
     }
-    response = requests.get(url, headers=headers)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Error downloading file from {url}: {e}")
+        raise
     with open(target_path, 'wb') as f:
         f.write(response.content)
 


### PR DESCRIPTION
## Summary
- add RequestException handling with 30s timeout when downloading files
- ensure GitHub PR and issue processing raises for HTTP errors and uses timeouts
- apply similar timeouts to other network helpers

## Testing
- `pytest -q` *(fails: Proxy error downloading ArXiv PDF; Proxy error retrieving https://docs.anthropic.com/)*

------
https://chatgpt.com/codex/tasks/task_e_68c4be4bdfdc832183b040c3a8453449