### PR TITLE
Pass console through process_input

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -2257,12 +2257,11 @@ def combine_xml_outputs(outputs):
     
     return '\n'.join(combined)
 
-async def process_input(input_path, args, progress=None, task=None):
+async def process_input(input_path, args, console, progress=None, task=None):
     """
     Process a single input path and return the XML output.
     Extracted from main() for reuse with multiple inputs.
     """
-    console = Console()
     urls_list_file = "processed_urls.txt"
     
     try:
@@ -2287,7 +2286,7 @@ async def process_input(input_path, args, progress=None, task=None):
                 result = process_arxiv_pdf(input_path)
             elif input_path.lower().endswith(('.pdf')): # Direct PDF link
                 # Simplified: wrap direct PDF processing if needed, or treat as web crawl
-                print("[bold yellow]Direct PDF URL detected - treating as single-page crawl.[/bold yellow]")
+                console.print("[bold yellow]Direct PDF URL detected - treating as single-page crawl.[/bold yellow]")
                 crawl_result = crawl_and_extract_text(input_path, max_depth=0, include_pdfs=True, ignore_epubs=True)
                 result = crawl_result['content']
                 if crawl_result['processed_urls']:
@@ -3612,7 +3611,7 @@ async def main(argv: Optional[List[str]] = None):
         try:
             # Process each input path
             for input_path in input_paths:
-                result = await process_input(input_path, args, progress, task)
+                result = await process_input(input_path, args, console, progress, task)
                 if result:
                     outputs.append(result)
                     console.print(f"[green]Successfully processed: {input_path}[/green]")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -326,7 +326,7 @@ class TestCoreProcessing(unittest.TestCase):
             mock_process.return_value = '<source type="local_file">Test content</source>'
             # Use a synchronous wrapper to test the async function
             import asyncio
-            result = asyncio.run(mock_process(test_file, None))
+            result = asyncio.run(mock_process(test_file, None, Console()))
             self.assertIn('<source type="local_file"', result)
             self.assertIn('Test content', result)
     
@@ -1481,7 +1481,7 @@ class TestErrorHandling(unittest.TestCase):
         with patch('onefilellm.process_input', new_callable=AsyncMock) as mock_process:
             mock_process.return_value = '<error>File not found</error>'
             import asyncio
-            result = asyncio.run(mock_process("/nonexistent/file/path.txt", None))
+            result = asyncio.run(mock_process("/nonexistent/file/path.txt", None, Console()))
             self.assertIn('error', result.lower())
     
     def test_invalid_url(self):
@@ -1490,7 +1490,7 @@ class TestErrorHandling(unittest.TestCase):
         with patch('onefilellm.process_input', new_callable=AsyncMock) as mock_process:
             mock_process.return_value = '<error>Invalid URL</error>'
             import asyncio
-            result = asyncio.run(mock_process("not_a_valid_url", None))
+            result = asyncio.run(mock_process("not_a_valid_url", None, Console()))
             self.assertIn('error', result.lower())
     
     def test_empty_input(self):
@@ -1555,7 +1555,7 @@ class TestPerformance(unittest.TestCase):
                 mock_process.return_value = '<source type="local_file">Large file content</source>'
                 start_time = time.time()
                 import asyncio
-                result = asyncio.run(mock_process(f.name, None))
+                result = asyncio.run(mock_process(f.name, None, Console()))
                 end_time = time.time()
                 
                 self.assertIn('<source type="local_file"', result)
@@ -1823,7 +1823,7 @@ class TestMultipleInputProcessing(unittest.TestCase):
             for input_item in inputs:
                 try:
                     import asyncio
-                    result = asyncio.run(mock_process(input_item, None))
+                    result = asyncio.run(mock_process(input_item, None, Console()))
                     results.append(result)
                 except Exception as e:
                     errors.append(str(e))


### PR DESCRIPTION
## Summary
- Accept a console parameter in `process_input` and remove internal instantiation
- Update `main` and tests to pass the existing console
- Use the shared console for direct PDF notices to keep Rich output consistent

## Testing
- `PYTHONPATH=$PWD RUN_INTEGRATION_TESTS=false pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4fba3bac48321a91680ba4cd237ff