### PR TITLE
Use console for local folder processing output

### DIFF
--- a/extras/web_app.py
+++ b/extras/web_app.py
@@ -2,15 +2,17 @@ from flask import Flask, request, render_template_string, send_file
 import os
 import sys
 
-# Import functions from onefilellm.py. 
+# Import functions from onefilellm.py.
 # Ensure onefilellm.py is accessible in the same directory.
 from onefilellm import process_github_repo, process_github_pull_request, process_github_issue
 from onefilellm import process_arxiv_pdf, process_local_folder, fetch_youtube_transcript
 from onefilellm import crawl_and_extract_text, process_doi_or_pmid, get_token_count, preprocess_text, safe_file_read
 from pathlib import Path
 import pyperclip
+from rich.console import Console
 
 app = Flask(__name__)
+console = Console()
 
 # Simple HTML template using inline rendering for demonstration.
 template = """
@@ -88,7 +90,7 @@ def index():
             elif (input_path.startswith("10.") and "/" in input_path) or input_path.isdigit():
                 final_output = process_doi_or_pmid(input_path)
             else:
-                final_output = process_local_folder(input_path)
+                final_output = process_local_folder(input_path, console)
 
             # Write the uncompressed output
             with open(output_file, "w", encoding="utf-8") as file:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -338,7 +338,8 @@ class TestCoreProcessing(unittest.TestCase):
             with open(test_file, 'w') as f:
                 f.write(f"Content {i}")
         
-        result = process_local_folder(self.temp_dir)
+        console = Console()
+        result = process_local_folder(self.temp_dir, console)
         self.assertIn('<source type="local_folder"', result)
         for i in range(3):
             self.assertIn(f'Content {i}', result)


### PR DESCRIPTION
## Summary
- Add `console` parameter to `process_local_folder` and its helper
- Replace `print` statements with `console.print`
- Update web app and tests to pass console instances

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4feb181748321a4aad8b1e0ac0b6b