### PR TITLE
Handle yt-dlp subprocess failures when fetching YouTube transcripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,3 +364,13 @@ python onefilellm.py --help-topic examples   # Advanced usage patterns
 python onefilellm.py --help-topic config     # Environment and configuration
 ```
 
+## Troubleshooting
+
+- **YouTube transcript errors**: Fetching YouTube transcripts requires the
+  [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) tool. If you see errors about
+  `yt-dlp` not being found or failing, install it with:
+
+  ```bash
+  pip install yt-dlp
+  ```
+


### PR DESCRIPTION
## Summary
- Capture yt-dlp stderr when subprocess fails and report a clear error message
- Add regression test simulating yt-dlp failure
- Note yt-dlp requirement in new Troubleshooting section

## Testing
- `PYTHONPATH=$PWD pytest tests/test_all.py::TestErrorHandling::test_youtube_subprocess_failure -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: Proxy error: HTTPSConnectionPool(host='arxiv.org', port=443)...)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ffdd8d7c83219bf9185f54fa4d48