### PR TITLE
Load .env configuration before computing runtime globals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,8 +1,7 @@
-import asyncio
-from onefilellm import main
+from onefilellm import run
 
 def entry_point():
-    asyncio.run(main())
+    run()
 
 if __name__ == "__main__":
     entry_point() 


### PR DESCRIPTION
## Summary
- initialize OneFileLLM configuration by loading .env values before computing OFFLINE_MODE, TOKEN, and headers
- ensure CLI entry point and run() helper refresh configuration to reflect environment changes
- add unit tests that mock dotenv loading to confirm configuration updates and default handling

## Testing
- PYTHONPATH=. pytest tests/test_all.py -k TestConfigurationLoading
- PYTHONPATH=. pytest tests/test_all.py *(fails: network-restricted integration tests that attempt to hit arxiv.org and docs.anthropic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68d15e7036888321a1f452ab8fa0e3f0