### PR TITLE
Ensure GitHub downloads forward auth headers

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -416,7 +416,7 @@ def process_github_repo(repo_url):
                     with tempfile.TemporaryDirectory() as temp_dir:
                         temp_file = os.path.join(temp_dir, file_info["name"])
                         try:
-                            download_file(file_info["download_url"], temp_file)
+                            download_file(file_info["download_url"], temp_file, headers=headers)
                             repo_content_list.append(f'\n<file path="{escape_xml(file_info["path"])}">')
                             if file_info["name"].endswith(".ipynb"):
                                 # Append raw code - escape_xml not needed as it does nothing


### PR DESCRIPTION
## Summary
- allow `utils.download_file` to merge optional headers and auto-attach Authorization tokens when available
- propagate GitHub request headers into repository file downloads so private assets can be fetched
- extend the test suite to cover header merging and ensure repository processing forwards Authorization

## Testing
- `PYTHONPATH=. python tests/test_all.py` *(fails for arXiv/web crawl integration cases in this environment due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d16584414c83218b91a454a6c4a950