### PR TITLE
Allow PDF and YML processing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -314,7 +314,7 @@ def is_allowed_filetype(filename: str) -> bool:
         True if file type is allowed, False otherwise
     """
     allowed_extensions = [
-        '.py', '.txt', '.js', '.rst', '.sh', '.md', '.pyx', '.html', '.yaml',
+        '.py', '.txt', '.js', '.rst', '.sh', '.md', '.pyx', '.html', '.yaml', '.yml', '.pdf',
         '.json', '.jsonl', '.ipynb', '.h', '.c', '.sql', '.csv', '.go', '.java',
         '.cpp', '.hpp', '.cs', '.php', '.rb', '.swift', '.kt', '.ts', '.tsx',
         '.jsx', '.vue', '.r', '.m', '.scala', '.rs', '.dart', '.lua', '.pl',


### PR DESCRIPTION
## Summary
- allow PDF and YML extensions in the shared file-type whitelist
- verify local folder processing emits PDF extraction output and YAML file contents
- add a GitHub repository unit test covering PDF and YML downloads

## Testing
- PYTHONPATH=. RUN_INTEGRATION_TESTS=false pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1675bc2fc83218b5ae6e13263a60d