### PR TITLE
Ensure tests set sys.path before importing repository modules

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -22,10 +22,10 @@ from rich.console import Console
 from rich.table import Table
 from rich.text import Text
 
-import onefilellm
-
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import onefilellm
 
 # Import the modules we're testing
 from onefilellm import (


### PR DESCRIPTION
## Summary
- move the sys.path insertion in tests/test_all.py ahead of importing project modules so that local imports succeed without relying on execution order

## Testing
- python tests/test_all.py *(fails: network-restricted integration tests that fetch external resources)*
- pytest *(fails: same network-restricted integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a0bb7e08321a146d20c6eb0de34