### PR TITLE
Normalize DOI/PMID handling in process_input

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -2346,7 +2346,13 @@ async def process_input(input_path, args, console, progress=None, task=None):
     
     try:
         console.print(f"\n[bold bright_green]Processing:[/bold bright_green] [bold bright_yellow]{input_path}[/bold bright_yellow]\n")
-        
+
+        # Normalize potential DOI/PMID identifiers that may include prefixes like "doi:" or "pmid:"
+        cleaned_identifier = input_path.strip()
+        prefix_match = re.match(r"^(doi|pmid)\s*:\s*(.+)$", cleaned_identifier, flags=re.IGNORECASE)
+        if prefix_match:
+            cleaned_identifier = prefix_match.group(2).strip()
+
         # Input type detection logic
         if "github.com" in input_path:
             parsed_url = urlparse(input_path)
@@ -2415,8 +2421,8 @@ async def process_input(input_path, args, console, progress=None, task=None):
                     # Note: The new crawler doesn't return processed_urls separately,
                     # they're included in the XML output if needed
         # Basic check for DOI (starts with 10.) or PMID (all digits)
-        elif (input_path.startswith("10.") and "/" in input_path) or input_path.isdigit():
-            result = process_doi_or_pmid(input_path)
+        elif (cleaned_identifier.startswith("10.") and "/" in cleaned_identifier) or cleaned_identifier.isdigit():
+            result = process_doi_or_pmid(cleaned_identifier)
         elif os.path.isdir(input_path): # Check if it's a local directory
             result = process_local_folder(input_path, console)
         elif os.path.isfile(input_path): # Handle single local file

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -452,6 +452,33 @@ class TestProcessInputFileURLs(unittest.TestCase):
             mock_crawl.assert_awaited_once()
 
 
+class TestProcessInputDoiPmid(unittest.TestCase):
+    """Test DOI and PMID handling and normalization in process_input."""
+
+    def setUp(self):
+        self.console = Console(file=io.StringIO())
+        self.args = type('Args', (), {})()
+
+    def test_process_input_normalizes_identifier_prefixes(self):
+        """Inputs with or without DOI/PMID prefixes should resolve to the same identifier."""
+        import asyncio
+
+        cases = [
+            ("10.1000/xyz123", "10.1000/xyz123"),
+            ("DOI:10.1000/xyz123", "10.1000/xyz123"),
+            ("doi: 10.1000/xyz123", "10.1000/xyz123"),
+            ("12345678", "12345678"),
+            ("PMID:12345678", "12345678"),
+        ]
+
+        for raw_input, expected_identifier in cases:
+            with self.subTest(raw_input=raw_input):
+                with patch('onefilellm.process_doi_or_pmid', return_value=f'result-{expected_identifier}') as mock_process:
+                    result = asyncio.run(process_input(raw_input, self.args, self.console))
+                    self.assertEqual(result, f'result-{expected_identifier}')
+                    mock_process.assert_called_once_with(expected_identifier)
+
+
 class TestCoreProcessing(unittest.TestCase):
     """Test core processing functions"""
     


### PR DESCRIPTION
## Summary
- normalize DOI and PMID inputs in `process_input` by trimming optional prefixes before detection
- pass the cleaned identifier to `process_doi_or_pmid` so downstream behavior stays consistent
- add regression coverage asserting prefixed and unprefixed DOI/PMID inputs invoke `process_doi_or_pmid` with the normalized value

## Testing
- pytest tests/test_all.py *(fails: integration tests require external network access)*
- RUN_INTEGRATION_TESTS=false pytest tests/test_all.py

------
https://chatgpt.com/codex/tasks/task_e_68d1756d1c4083218bb0f31348a0dd55