### PR TITLE
Respect offline mode in new web crawler

### DIFF
--- a/onefilellm.py
+++ b/onefilellm.py
@@ -1862,6 +1862,11 @@ async def process_web_crawl(base_url: str, cli_args: object, console: Console, p
     Returns:
         XML string with crawled content
     """
+    if OFFLINE_MODE:
+        msg = "Offline mode enabled; skipping web crawl"
+        console.print(f"[bold yellow]{msg}[/bold yellow]")
+        return f'<source type="web_crawl" base_url="{escape_xml(base_url)}"><error>{escape_xml(msg)}</error></source>'
+
     console.print(f"\n[bold green]Initiating web crawl for:[/bold green] [bright_yellow]{base_url}[/bright_yellow]")
     
     # Create and run the DocCrawler

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1756,6 +1756,40 @@ class TestOfflineMode(unittest.TestCase):
         self.assertIn('Offline mode enabled', result)
         mock_get.assert_not_called()
 
+    def test_process_web_crawl_offline(self):
+        import asyncio
+
+        console = Console(file=io.StringIO())
+        args = type('Args', (), {})()
+
+        with patch('onefilellm.DocCrawler') as mock_crawler:
+            result = asyncio.run(
+                onefilellm.process_web_crawl('https://example.com', args, console, progress_bar=None)
+            )
+
+        self.assertIn('<source type="web_crawl"', result)
+        self.assertIn('Offline mode enabled', result)
+        mock_crawler.assert_not_called()
+        self.assertIn('Offline mode enabled; skipping web crawl', console.file.getvalue())
+
+    def test_process_github_pull_request_offline(self):
+        with patch('requests.get') as mock_get:
+            result = process_github_pull_request('https://github.com/user/repo/pull/1')
+        self.assertIn('Offline mode enabled', result)
+        mock_get.assert_not_called()
+
+    def test_process_github_issue_offline(self):
+        with patch('requests.get') as mock_get:
+            result = process_github_issue('https://github.com/user/repo/issues/1')
+        self.assertIn('Offline mode enabled', result)
+        mock_get.assert_not_called()
+
+    def test_process_github_issues_offline(self):
+        with patch('requests.get') as mock_get:
+            result = process_github_issues('https://github.com/user/repo/issues')
+        self.assertIn('Offline mode enabled', result)
+        mock_get.assert_not_called()
+
 
 class TestTemporaryFileCollisions(unittest.TestCase):
     """Ensure temporary file handling avoids name collisions."""


### PR DESCRIPTION
## Summary
- short-circuit the new DocCrawler entry point when OFFLINE_MODE is enabled and mirror the legacy crawler messaging
- add regression tests covering the new crawler and GitHub fetchers to ensure they remain offline-safe

## Testing
- RUN_INTEGRATION_TESTS=false pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17d93bd208321bdbee1ee33688af6