### PR TITLE
Allow CSS files to be processed

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -190,6 +190,7 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertTrue(is_allowed_filetype("config.yaml"))
         self.assertTrue(is_allowed_filetype("config.yml"))
         self.assertTrue(is_allowed_filetype("document.PDF"))
+        self.assertTrue(is_allowed_filetype("styles.css"))
         self.assertFalse(is_allowed_filetype("image.png"))
         self.assertFalse(is_allowed_filetype("binary.exe"))
         self.assertFalse(is_allowed_filetype("archive.zip"))

--- a/utils.py
+++ b/utils.py
@@ -316,7 +316,7 @@ def is_allowed_filetype(filename: str) -> bool:
     allowed_extensions = [
         '.py', '.txt', '.js', '.rst', '.sh', '.md', '.pyx', '.html', '.yaml', '.yml', '.pdf',
         '.json', '.jsonl', '.ipynb', '.h', '.c', '.sql', '.csv', '.go', '.java',
-        '.cpp', '.hpp', '.cs', '.php', '.rb', '.swift', '.kt', '.ts', '.tsx',
+        '.cpp', '.hpp', '.cs', '.php', '.rb', '.swift', '.kt', '.ts', '.tsx', '.css',
         '.jsx', '.vue', '.r', '.m', '.scala', '.rs', '.dart', '.lua', '.pl',
         '.jl', '.mat', '.asm', '.s', '.pas', '.fs', '.ml', '.ex', '.clj',
         '.hs', '.lsp', '.scm', '.nim', '.zig', '.d', '.ada', '.f90', '.cob',


### PR DESCRIPTION
## Summary
- allow the file classifier to treat .css as a text asset eligible for processing
- extend the unit test coverage to include CSS files in the allowed list

## Testing
- pytest *(fails: network-restricted integration tests that contact arxiv.org and docs.anthropic.com)*
- pytest tests/test_all.py::TestUtilityFunctions::test_is_allowed_filetype


------
https://chatgpt.com/codex/tasks/task_e_68d41adb268083219c4c56c893ab9bdc